### PR TITLE
feat(eslint-config-fueled-node): make no-unnecessary-condition a warn, update @typescript-eslint

### DIFF
--- a/packages/eslint-config-fueled-node/index.js
+++ b/packages/eslint-config-fueled-node/index.js
@@ -140,7 +140,7 @@ module.exports = {
 
     // Avoid unnecessary conditionals.
     // https://typescript-eslint.io/rules/no-unnecessary-condition
-    "@typescript-eslint/no-unnecessary-condition": "error",
+    "@typescript-eslint/no-unnecessary-condition": "warn",
 
     // Warn against unnecessary type assertions.
     // https://typescript-eslint.io/rules/no-unnecessary-type-assertion

--- a/packages/eslint-config-fueled-node/package.json
+++ b/packages/eslint-config-fueled-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fueled/eslint-config-fueled-node",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Fueled TypeScript ESLint config for Node.",
   "main": "index.js",
   "scripts": {
@@ -22,17 +22,17 @@
     "printWidth": 100
   },
   "dependencies": {
-    "@typescript-eslint/parser": "^6.12.0",
-    "eslint-config-prettier": "^9.0.0",
-    "eslint-plugin-jest": "^27.6.0",
-    "eslint-plugin-prettier": "^5.0.1"
+    "@typescript-eslint/parser": "^7.3.1",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-jest": "^27.9.0",
+    "eslint-plugin-prettier": "^5.1.3"
   },
   "devDependencies": {
-    "prettier": "^3.1.0",
-    "typescript": "^5.3.2"
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.3"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^6.12.0",
-    "eslint": "^8.54.0"
+    "@typescript-eslint/eslint-plugin": "^7.3.1",
+    "eslint": "^8.57.0"
   }
 }


### PR DESCRIPTION
This PR introduces the following changes:
- Make `@typescript-eslint/no-unnecessary-condition` rules act as a warning, rather than an error. Error causes issues in certain cases, and to avoid them requires writing workarounds in TS that should not be necessary. Specifically when working with 3rd party API payloads.
- Update `@typescript-eslint` packages.
- Bump version to 1.2.0.